### PR TITLE
Hide regex field behind Advanced toggle and fix keep_last_digits for …

### DIFF
--- a/logic.py
+++ b/logic.py
@@ -1372,7 +1372,7 @@ def redact_pdf_bytes(pdf_bytes: bytes, patterns: List[re.Pattern], keep_last_dig
                                 snippet = " ".join(wd for wd in words[lo:hi] if wd)
                                 if not SSN_CONTEXT_WORDS.search(snippet or ""):
                                     continue
-                            if keep_last_digits > 0:
+                            if keep_last_digits > 0 and _is_ssn_pat(pat):
                                 num_digits = sum(ch.isdigit() for ch in word)
                                 if num_digits > keep_last_digits:
                                     redact_ratio = (num_digits - keep_last_digits) / max(num_digits, 1)
@@ -1423,7 +1423,7 @@ def redact_pdf_bytes(pdf_bytes: bytes, patterns: List[re.Pattern], keep_last_dig
                         continue
                     if require_ssn_context and _is_ssn_pat(pat) and not _passes_ssn_context_text(page_text, m):
                         continue
-                    if keep_last_digits > 0:
+                    if keep_last_digits > 0 and _is_ssn_pat(pat):
                         prefix = prefix_excluding_last_n_digits(s, keep_last_digits)
                         if prefix:
                             partial_prefixes.append(prefix)

--- a/wordpress-plugin/rlg-discovery-integration/public/shortcodes.php
+++ b/wordpress-plugin/rlg-discovery-integration/public/shortcodes.php
@@ -210,12 +210,18 @@ function rlg_shortcode_redact($atts) {
             <section class="rlg-section-flex rlg-divider">
                 <h4>Custom Patterns</h4>
                 <div class="rlg-form-group">
-                    <label>Regex Patterns (one per line)</label>
-                    <textarea name="regex_patterns" rows="3" placeholder="e.g., \b\d{4}-\d{4}\b"></textarea>
-                </div>
-                <div class="rlg-form-group">
                     <label>Literal Patterns (comma separated)</label>
                     <input type="text" name="literal_patterns" placeholder="e.g., CONFIDENTIAL, SECRET">
+                </div>
+                <div class="rlg-form-group rlg-checkbox-toggle">
+                    <label>
+                        <input type="checkbox" id="toggle-advanced-regex" data-target="advanced-regex-field">
+                        Advanced: Use Regex
+                    </label>
+                </div>
+                <div class="rlg-form-group rlg-toggle-field" id="advanced-regex-field" style="display: none;">
+                    <label>Regex Patterns (one per line)</label>
+                    <textarea name="regex_patterns" rows="3" placeholder="e.g., \b\d{4}-\d{4}\b"></textarea>
                 </div>
                 <div class="rlg-form-group rlg-checkbox-toggle">
                     <label>


### PR DESCRIPTION
…SSN only

- Move Literal Patterns field to top of Custom Patterns section (most common use case)
- Add "Advanced: Use Regex" toggle to show/hide regex patterns field
- Fix bug where keep_last_digits was applied to all patterns instead of SSN only

## Summary by Sourcery

Update custom redaction pattern UI and constrain SSN digit-keeping logic to SSN patterns only.

New Features:
- Add an Advanced toggle to show or hide the regex custom patterns field in the shortcode UI.

Bug Fixes:
- Restrict keep_last_digits behavior so it only applies to SSN patterns instead of all patterns.