### PR TITLE
Changed the preview for literal string form input

### DIFF
--- a/logic/redaction.py
+++ b/logic/redaction.py
@@ -455,20 +455,21 @@ def process_zip_bytes(
     with zipfile.ZipFile(out_buf, 'w', compression=zipfile.ZIP_DEFLATED) as zout:
         for arcname, data in redacted_files:
             zout.writestr(arcname, data)
-        csv_s = io.StringIO()
-        cw = csv.writer(csv_s)
-        cw.writerow(["file", "page", "pattern", "match"])
-        for h in audit_hits:
-            cw.writerow([h.rel_path, h.page_num, h.pattern, h.matched_text])
-        zout.writestr("audit.csv", csv_s.getvalue().encode("utf-8"))
-        report = {
-            "files_processed": len(redacted_files),
-            "total_hits": len(audit_hits),
-            "patterns": [p.pattern for p in patterns],
-            "keep_last_digits": keep_last_digits,
-            "require_ssn_context": require_ssn_context,
-        }
-        zout.writestr("report.json", json.dumps(report, indent=2).encode("utf-8"))
+#         ======== This code that is commented out is for an audit.csv file and a report.json file that were used for testing ========
+#         csv_s = io.StringIO()
+#         cw = csv.writer(csv_s)
+#         cw.writerow(["file", "page", "pattern", "match"])
+#         for h in audit_hits:
+#             cw.writerow([h.rel_path, h.page_num, h.pattern, h.matched_text])
+#         zout.writestr("audit.csv", csv_s.getvalue().encode("utf-8"))
+#         report = {
+#             "files_processed": len(redacted_files),
+#             "total_hits": len(audit_hits),
+#             "patterns": [p.pattern for p in patterns],
+#             "keep_last_digits": keep_last_digits,
+#             "require_ssn_context": require_ssn_context,
+#         }
+#         zout.writestr("report.json", json.dumps(report, indent=2).encode("utf-8"))
 
     return out_buf.getvalue(), audit_hits, {
         "files_processed": len(redacted_files),

--- a/wordpress-plugin/rlg-discovery-integration/public/shortcodes.php
+++ b/wordpress-plugin/rlg-discovery-integration/public/shortcodes.php
@@ -221,7 +221,7 @@ function rlg_shortcode_redact($atts) {
                 <h4>Custom Patterns</h4>
                 <div class="rlg-form-group">
                     <label>Literal Patterns (comma separated)</label>
-                    <input type="text" name="literal_patterns" placeholder="e.g., CONFIDENTIAL, SECRET">
+                    <input type="text" name="literal_patterns" placeholder="e.g., 000001, 000AB2">
                 </div>
                 <div class="rlg-form-group rlg-checkbox-toggle">
                     <label>


### PR DESCRIPTION
Removed the additional files downloaded when redaction tool is used

## Summary by Sourcery

Remove test-only audit artifacts from redaction output and update the literal patterns input preview in the WordPress integration.

Bug Fixes:
- Stop including audit.csv and report.json files in redaction zip downloads.

Enhancements:
- Update the placeholder example text for literal pattern input in the WordPress redaction shortcode form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Audit and report files are no longer generated in ZIP exports.

* **Style**
  * Updated placeholder text in the Literal Patterns input field for improved clarity on accepted input format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->